### PR TITLE
Add Proxy support

### DIFF
--- a/examples/basic.go
+++ b/examples/basic.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"github.com/mariuspass/recws"
+	"github.com/timmersuk/recws"
 	"log"
 	"time"
 )

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"github.com/timmersuk/recws"
+	"github.com/mariusws/recws"
 	"log"
 	"time"
 )

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"github.com/mariusws/recws"
+	"github.com/mariuspass/recws"
 	"log"
 	"time"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/mariuspass/recws
+
+require (
+	github.com/gorilla/websocket v1.4.0
+	github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7
+)


### PR DESCRIPTION
Just a small change to allow recws to support use via a proxy - defaults the proxy dialer to using the go standard ProxyFromEnvironment setting.